### PR TITLE
Rename instances of Map<NodeConnection<NodeInfo>, PacketPipeline<Mail>> 'networkConditions' to 'nodeConnectionToPacketPipelineMap'

### DIFF
--- a/src/main/java/thorpe/luke/network/simulation/PacketCourierSimulation.java
+++ b/src/main/java/thorpe/luke/network/simulation/PacketCourierSimulation.java
@@ -643,7 +643,7 @@ public class PacketCourierSimulation<NodeInfo> {
 
       // Configure packet pipeline logic.
       LocalDateTime startTime = clock.now();
-      Map<NodeConnection<NodeInfo>, PacketPipeline<Mail>> networkConditions =
+      Map<NodeConnection<NodeInfo>, PacketPipeline<Mail>> nodeConnectionToPacketPipelineMap =
           nodeConnectionToPacketPipelineFactoryMap
               .entrySet()
               .stream()
@@ -657,7 +657,8 @@ public class PacketCourierSimulation<NodeInfo> {
 
       // Configure simulation logic.
       PacketCourierPostalService<NodeInfo> postalService =
-          new PacketCourierPostalService<>(nameToNodeMap.values(), networkConditions);
+          new PacketCourierPostalService<>(
+              nameToNodeMap.values(), nodeConnectionToPacketPipelineMap);
 
       return new PacketCourierSimulation<>(
           simulationName,

--- a/src/main/java/thorpe/luke/network/simulation/mail/PacketCourierPostalService.java
+++ b/src/main/java/thorpe/luke/network/simulation/mail/PacketCourierPostalService.java
@@ -17,19 +17,21 @@ import thorpe.luke.network.simulation.worker.WorkerAddress;
 
 public class PacketCourierPostalService<NodeInfo> implements PostalService {
   private final Map<NodeAddress, Node<NodeInfo>> nodeToAddressMap;
-  private final ConcurrentMap<NodeConnection<NodeInfo>, PacketPipeline<Mail>> networkConditions;
+  private final ConcurrentMap<NodeConnection<NodeInfo>, PacketPipeline<Mail>>
+      nodeConnectionToPacketPipelineMap;
 
   public PacketCourierPostalService(
       Collection<Node<NodeInfo>> nodes,
-      Map<NodeConnection<NodeInfo>, PacketPipeline<Mail>> networkConditions) {
+      Map<NodeConnection<NodeInfo>, PacketPipeline<Mail>> nodeConnectionToPacketPipelineMap) {
     this.nodeToAddressMap =
         nodes.stream().collect(Collectors.toMap(Node::getAddress, Function.identity()));
-    this.networkConditions = new ConcurrentHashMap<>(networkConditions);
+    this.nodeConnectionToPacketPipelineMap =
+        new ConcurrentHashMap<>(nodeConnectionToPacketPipelineMap);
   }
 
   public void tick(LocalDateTime now) {
     for (Entry<NodeConnection<NodeInfo>, PacketPipeline<Mail>> networkConditionEntry :
-        networkConditions.entrySet()) {
+        nodeConnectionToPacketPipelineMap.entrySet()) {
       NodeConnection<NodeInfo> nodeConnection = networkConditionEntry.getKey();
       PacketPipeline<Mail> packetPipeline = networkConditionEntry.getValue();
       packetPipeline.tick(now);
@@ -48,7 +50,7 @@ public class PacketCourierPostalService<NodeInfo> implements PostalService {
       return false;
     }
     PacketPipeline<Mail> packetPipeline =
-        networkConditions.get(new NodeConnection<>(source, destination));
+        nodeConnectionToPacketPipelineMap.get(new NodeConnection<>(source, destination));
     if (packetPipeline == null) {
       return false;
     }


### PR DESCRIPTION
Resolves #140.